### PR TITLE
Add RMS and derivative features

### DIFF
--- a/model3/model.py
+++ b/model3/model.py
@@ -6,8 +6,9 @@ class InverseGainMLP(nn.Module):
         super().__init__()
 
         # --- 1. Ortak Paylaşımlı Katmanlar (Shared MLP) ---
+        # Giriş boyutu 255 ham kazanç + 18 ek özellik = 273
         self.shared = nn.Sequential(
-            nn.Linear(267, 512),
+            nn.Linear(273, 512),
             nn.LayerNorm(512),
             nn.ReLU(inplace=True),
             nn.Dropout(p=0.2),
@@ -41,7 +42,7 @@ class InverseGainMLP(nn.Module):
         ])
 
     def forward(self, x):
-        # x: [batch_size, 267]
+        # x: [batch_size, 273]
         shared_out = self.shared(x)   # [batch_size, 128]
         fused = self.fusion(shared_out)  # [batch_size, 64]
         outputs = [head(fused) for head in self.heads]  # Liste: 10 × [batch_size, 1]

--- a/model3/predict_and_netlist.py
+++ b/model3/predict_and_netlist.py
@@ -49,7 +49,7 @@ plt.tight_layout()
 plt.show()
 
 # ----------------------------------------
-# 5. Feature Engineering (Model’in Beklediği 267 Boyutlu Vektör)
+# 5. Feature Engineering (Model’in Beklediği 273 Boyutlu Vektör)
 # ----------------------------------------
 gain_row_2d = gain_row.reshape(1, -1)  # (1, 255)
 
@@ -68,20 +68,32 @@ band1_mean = gain_row_2d[:, :5].mean(axis=1, keepdims=True)
 band2_mean = gain_row_2d[:, 5:20].mean(axis=1, keepdims=True)
 band3_mean = gain_row_2d[:, 20:50].mean(axis=1, keepdims=True)
 
+# RMS ve türev tabanlı özellikler (scaling.py ile aynı mantık)
+band1_rms = np.sqrt(np.mean(np.square(gain_row_2d[:, :5]), axis=1, keepdims=True))
+band2_rms = np.sqrt(np.mean(np.square(gain_row_2d[:, 5:20]), axis=1, keepdims=True))
+band3_rms = np.sqrt(np.mean(np.square(gain_row_2d[:, 20:50]), axis=1, keepdims=True))
+
+first_deriv = np.diff(gain_row_2d, axis=1)
+deriv_mean = first_deriv.mean(axis=1, keepdims=True)
+deriv_std = first_deriv.std(axis=1, keepdims=True)
+deriv_abs_mean = np.mean(np.abs(first_deriv), axis=1, keepdims=True)
+
 X_extra = np.hstack([
     gain_max, gain_min, gain_mean,
     low_freq_mean, high_freq_mean,
     gain_drop,
     gain_std, gain_skew, gain_kurt,
-    band1_mean, band2_mean, band3_mean
-])  # (1, 12)
+    band1_mean, band2_mean, band3_mean,
+    band1_rms, band2_rms, band3_rms,
+    deriv_mean, deriv_std, deriv_abs_mean
+])  # (1, 18)
 
-X_full = np.hstack([gain_row_2d, X_extra])  # (1, 267)
+X_full = np.hstack([gain_row_2d, X_extra])  # (1, 273)
 
 # ----------------------------------------
 # 6. Girdiyi Scaler’dan Geçir ve Torch Tensor’a Dönüştür
 # ----------------------------------------
-X_scaled = scaler_X.transform(X_full)                      # (1, 267)
+X_scaled = scaler_X.transform(X_full)                      # (1, 273)
 X_tensor = torch.tensor(X_scaled, dtype=torch.float32).to(device)
 
 # ----------------------------------------

--- a/model3/scaling.py
+++ b/model3/scaling.py
@@ -23,9 +23,23 @@ high_freq_mean = X_raw[:, -10:].mean(axis=1, keepdims=True)
 gain_drop = (X_raw[:, 0] - X_raw[:, -1]).reshape(-1, 1)
 
 # Yeni eklenen öznitelikler:
+#  - gain_std: Tüm kazanç eğrisinin standart sapması
+#  - gain_skew / gain_kurt: Çarpıklık ve basıklık değerleri
 gain_std = X_raw.std(axis=1, keepdims=True)
 gain_skew = skew(X_raw, axis=1).reshape(-1, 1)
 gain_kurt = kurtosis(X_raw, axis=1).reshape(-1, 1)
+
+# --- Ek Öznitelikler: Bant RMS ve türev istatistikleri ---
+# Bant RMS hesaplamaları (farklı frekans aralıklarının enerji seviyesi)
+band1_rms = np.sqrt(np.mean(np.square(X_raw[:, :5]), axis=1, keepdims=True))
+band2_rms = np.sqrt(np.mean(np.square(X_raw[:, 5:20]), axis=1, keepdims=True))
+band3_rms = np.sqrt(np.mean(np.square(X_raw[:, 20:50]), axis=1, keepdims=True))
+
+# Birinci dereceden türev (yaklaşık eğri eğimi)
+first_deriv = np.diff(X_raw, axis=1)
+deriv_mean = first_deriv.mean(axis=1, keepdims=True)
+deriv_std = first_deriv.std(axis=1, keepdims=True)
+deriv_abs_mean = np.mean(np.abs(first_deriv), axis=1, keepdims=True)
 
 # Band ortalamaları (örnek olarak 3 bant):
 band1_mean = X_raw[:, :5].mean(axis=1, keepdims=True)    # ilk 5 frekans bölgesi
@@ -38,10 +52,13 @@ X_extra = np.hstack([
     low_freq_mean, high_freq_mean,
     gain_drop,
     gain_std, gain_skew, gain_kurt,
-    band1_mean, band2_mean, band3_mean
-])  # → (n_samples, 12 ek özellik)
+    band1_mean, band2_mean, band3_mean,
+    # RMS değerleri ve türev istatistikleri
+    band1_rms, band2_rms, band3_rms,
+    deriv_mean, deriv_std, deriv_abs_mean
+])  # → (n_samples, 18 ek özellik)
 
-X_full = np.hstack([X_raw, X_extra])  # (n_samples, 255 + 12 = 267)
+X_full = np.hstack([X_raw, X_extra])  # (n_samples, 255 + 18 = 273)
 
 # === 4. GİRİŞ SCALING ===
 scaler_X = MinMaxScaler()
@@ -76,7 +93,7 @@ print("✅ Scaler dosyaları 'scalers/' klasörüne kaydedildi.")
 
 # === 10. KONTROL ÇIKTISI ===
 print("✅ Scaling tamamlandı:")
-print("🔸 Giriş boyutu (X):", X_tensor.shape)    # örn: (258489, 267)
+print("🔸 Giriş boyutu (X):", X_tensor.shape)    # örn: (258489, 273)
 print("🔸 Çıkış boyutu (y):", y_tensor.shape)    # örn: (258489, 10)
 print("🔧 Giriş sütunu sayısı:", X_tensor.shape[1])
 print("🔧 Çıkış komponentleri:", component_cols)


### PR DESCRIPTION
## Summary
- compute RMS and derivative stats when scaling
- adjust model input size accordingly
- update prediction script for new features

## Testing
- `python -m py_compile model3/*.py`
- `python model3/scaling.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6843737be580832eadc528c9e3f3d057