### PR TITLE
Add depth to MLP architecture

### DIFF
--- a/model3/model.py
+++ b/model3/model.py
@@ -10,14 +10,19 @@ class InverseGainMLP(nn.Module):
             nn.Linear(267, 512),
             nn.LayerNorm(512),
             nn.ReLU(inplace=True),
-            nn.Dropout(p=0.2),
+            nn.Dropout(p=0.3),
 
             nn.Linear(512, 256),
             nn.LayerNorm(256),
             nn.ReLU(inplace=True),
-            nn.Dropout(p=0.2),
+            nn.Dropout(p=0.3),
 
             nn.Linear(256, 128),
+            nn.LayerNorm(128),
+            nn.ReLU(inplace=True),
+            nn.Dropout(p=0.2),
+
+            nn.Linear(128, 128),
             nn.LayerNorm(128),
             nn.ReLU(inplace=True)
         )
@@ -27,7 +32,10 @@ class InverseGainMLP(nn.Module):
             nn.Linear(128, 64),
             nn.LayerNorm(64),
             nn.ReLU(inplace=True),
-            nn.Dropout(0.2)
+            nn.Dropout(0.25),
+            nn.Linear(64, 64),
+            nn.LayerNorm(64),
+            nn.ReLU(inplace=True)
         )
 
         # --- 3. Çıkış Head'leri (Her bir komponent için) ---


### PR DESCRIPTION
## Summary
- tweak `InverseGainMLP` with extra layers and new dropouts
- attempt to run training

## Testing
- `python3 model3/train.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684373739864832e885a7f3e309016d5